### PR TITLE
Fixed Experimental Torpedo Bay

### DIFF
--- a/src/js/common/utopia-card-rules.js
+++ b/src/js/common/utopia-card-rules.js
@@ -829,7 +829,7 @@ intercept: {
 		 ship: {
 			 canEquip: function(upgrade,ship,fleet) {
 				 var cost = valueOf(upgrade,"cost",ship,fleet);
-				 return cost <= 5;
+				 return cost <= 6;
 
 			return canEquip;
 		},


### PR DESCRIPTION
Fix for issue #8. New code allows for Torpeodes that cost 5 SP to be equipped with no faction penalty. 