### PR TITLE
Removed build dir in the ./src dir

### DIFF
--- a/src/staw-utopia/index.html
+++ b/src/staw-utopia/index.html
@@ -1,1 +1,0 @@
-<script>window.location.href = window.location.href.replace('staw-utopia/index.html', '')</script>


### PR DESCRIPTION
Looks like there was a build directory, `staw-utopia/` in the `src` directory, appearing as `src/staw-utopia/` with a single `index.html`. I am guessing this was an accidental build that then was accidentally committed.