### PR TITLE
Fix scout cube missing number

### DIFF
--- a/src/data/sets.js
+++ b/src/data/sets.js
@@ -1459,7 +1459,7 @@ module.exports = [
 		type: "set",
 		id: "71525",
 		gameId: 1,
-		name: "Scout Cube",
+		name: "Scout 608",
 		releaseDate: "2014-09-03",
 		parentSet: "Wave 7"
 	},


### PR DESCRIPTION
Fixes #185 
Scout 255  has a number, so Scout 608 should too.

Build not verified locally as this is a tiny change which looks like it won't have any knock on effects.

(Sorry, meant to create the branch on a fork, but oh well)