### PR TITLE
Made it so Grunt-Ugilfy includes sources in sourcemapping.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -56,7 +56,9 @@ module.exports = function(grunt) {
 					"staw-utopia/js/utopia.min.js": [ "src/js/*.js", "src/js/common/*.js", "<%= ngtemplates.utopia.dest %>" ]
 				},
 				options: {
-					sourceMap: true,
+					sourceMap: {
+						includeSources: true
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Tested locally. I am not sure if this is appropriate for the production version.