### PR TITLE
Fixed Vanik rules and tested locally.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -56,7 +56,9 @@ module.exports = function(grunt) {
 					"staw-utopia/js/utopia.min.js": [ "src/js/*.js", "src/js/common/*.js", "<%= ngtemplates.utopia.dest %>" ]
 				},
 				options: {
-					sourceMap: true,
+					sourceMap: {
+						includeSources: true
+					}
 				}
 			}
 		},

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -56,9 +56,7 @@ module.exports = function(grunt) {
 					"staw-utopia/js/utopia.min.js": [ "src/js/*.js", "src/js/common/*.js", "<%= ngtemplates.utopia.dest %>" ]
 				},
 				options: {
-					sourceMap: {
-						includeSources: true
-					}
+					sourceMap: true,
 				}
 			}
 		},

--- a/src/js/common/utopia-card-rules.js
+++ b/src/js/common/utopia-card-rules.js
@@ -257,6 +257,17 @@ module.factory( "cardRules", [ "$filter", "$factions", function($filter, $factio
 		return returnValue;
 	}
 
+	var getOccupiedSlot = function(upgrade, ship){
+		var id = upgrade.id;
+		for ( var i = 0; i < ship.upgrades.length; i++) {
+			var slotUpgrade = ship.upgrades[i];
+			if (slotUpgrade?.occupant?.id == id) {
+				return slotUpgrade.type[0];
+			}
+		}
+		return null;
+	}
+
 	// the following return object represents a massive lookup table to resolve special card rules by a key of "cardType:cardId"
 	return {
 
@@ -2115,7 +2126,7 @@ intercept: {
 				ship: {
 					// All Vulcan/Federation tech is -2 SP
 					cost: function(upgrade, ship, fleet, cost) {
-					if( ( $factions.hasFaction(upgrade,"federation", ship, fleet) || $factions.hasFaction(upgrade,"bajoran", ship, fleet) || $factions.hasFaction(upgrade,"vulcan", ship, fleet) ) && upgrade.type == "tech" )
+					if( ( $factions.hasFaction(upgrade,"federation", ship, fleet) || $factions.hasFaction(upgrade,"bajoran", ship, fleet) || $factions.hasFaction(upgrade,"vulcan", ship, fleet) ) && getOccupiedSlot(upgrade, ship) == "tech" )
 							return resolve(upgrade, ship, fleet, cost) - 2;
 						return cost;
 					},

--- a/src/js/common/utopia-card-rules.js
+++ b/src/js/common/utopia-card-rules.js
@@ -107,6 +107,9 @@ module.factory( "$factions", [ "$filter", function($filter) {
 	            let isConsideredInFaction = factions.includes(faction) || primeFactions.includes(faction);
 	            return isConsideredInFaction;
 	        },
+			hasAnyFaction: function(card, factions, ship, fleet) {
+				return factions.some(f => this.hasFaction(card, f, ship, fleet));
+			},		
 	        match: function(card, other, ship, fleet) {
 	            var match = false;
 	            $.each( valueOf(card,"factions",ship,fleet), function(i, cardFaction) {
@@ -263,10 +266,11 @@ module.factory( "cardRules", [ "$filter", "$factions", function($filter, $factio
 		for ( var i = 0; i < ship.upgrades.length; i++) {
 			var slotUpgrade = ship.upgrades[i];
 			if (slotUpgrade?.occupant?.id == id) {
-				return slotUpgrade.type[0];
+				return slotUpgrade;
 			}
 		}
 		return null;
+	}
 
 	var hasDaharMaster = function(card){
 		var foundDaharMasterTalent = false;
@@ -2139,7 +2143,7 @@ intercept: {
 				ship: {
 					// All Vulcan/Federation tech is -2 SP
 					cost: function(upgrade, ship, fleet, cost) {
-					if( ( $factions.hasFaction(upgrade,"federation", ship, fleet) || $factions.hasFaction(upgrade,"bajoran", ship, fleet) || $factions.hasFaction(upgrade,"vulcan", ship, fleet) ) && getOccupiedSlot(upgrade, ship) == "tech" )
+					if ( $factions.hasAnyFaction(upgrade,["federation","bajoran", "vulcan"], ship, fleet) && (upgrade.type == "tech" || getOccupiedSlot(upgrade, ship)?.type?.includes("tech") ))
 							return resolve(upgrade, ship, fleet, cost) - 2;
 						return cost;
 					},


### PR DESCRIPTION
Added a utility function to check if current visiting (I believe this app uses the visitor design pattern?) upgrade card is occupying a tech slot on the ship. Added this to the Vanik rules and used this instead of checking the type of the upgrade.
